### PR TITLE
FIX: Make nodejs checks optional. Closes #6

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,7 @@ ALX test Suite. Shell Utility that checks for ALX Project Requirements
 ### C
 
 - runs `betty` check.
-
-> Note: You would have to make sure betty is installed. Check out [How To Install Betty](https://youtu.be/wDDKOOEPED0?ref=alxcheck)
+  > Note: You would have to make sure betty is installed. Check out [How To Install Betty](https://youtu.be/wDDKOOEPED0?ref=alxcheck)
 
 ### Python
 
@@ -36,11 +35,11 @@ ALX test Suite. Shell Utility that checks for ALX Project Requirements
 ### JavaScript
 
 - Javascript file is executable
+  > Note: enabled with `-js` or `--nodejs-project` commandline switch. See [Usage](#usage) below
 - *shebang* is present and at the top of the file (`#!/usr/bin/node` or `#!/usr/bin/env node`)
+  > Note: enabled with `-js` or `--nodejs-project` commandline switch. See [Usage](#usage) below
 - `semistandard` check
-
-> Note: you would have to install semistandard `npm install semistandard -g`
-
+  > Note: you would have to install semistandard `npm install semistandard -g`
 - `var` is not used.
 
 ## Installation
@@ -57,13 +56,21 @@ python3 -m pip install alxcheck
 
 ## Usage
 
-After installation, to use this package, just run it as a shell command
+After installation, to use this package, just run it as a shell command. This starts the checks with the current working directory as the root of the project.
 
 ```bash
 alxcheck
 ```
 
-This starts the checks with the current working directory as the root of the project.
+If the project is a JavaScript project with node.js scripts, a commandline switch can be used to enable the first two checks [listed above](#javascript).
+
+```bash
+alxcheck -js #shorthand version
+```
+or
+```bash
+alxcheck --nodejs-project #long version
+```
 
 ## Contributing
 

--- a/alxcheck/main.py
+++ b/alxcheck/main.py
@@ -1,7 +1,6 @@
-import os
 import sys
 from .checks import *
-from .utils.helpers import is_python_virtual_env_folder
+from .utils.helpers import *
 from .utils.error_logging import *
 
 
@@ -40,10 +39,11 @@ def main():
                 pycodestyle_check(file_path)
             # javascript checks
             if file.endswith(".js"):
-                if not check_file_is_executable(file_path):
-                    print_file_not_executable(file_path)
-                if not check_javascript_shebang(file_path):
-                    print_no_shebang(file_path)
+                if is_nodejs_project():
+                    if not check_file_is_executable(file_path):
+                        print_file_not_executable(file_path)
+                    if not check_javascript_shebang(file_path):
+                        print_no_shebang(file_path)
                 if not check_no_var(file_path):
                     print_var_was_used(file_path)
                 semistandard_check(file_path)

--- a/alxcheck/utils/helpers.py
+++ b/alxcheck/utils/helpers.py
@@ -1,5 +1,15 @@
 import os
+import sys
 
 
 def is_python_virtual_env_folder(folder_path):
     return os.path.exists(f"{folder_path}/pyvenv.cfg")
+
+
+def is_nodejs_project():
+    """Checks for node.js commandline switches"""
+    switches = ('-js', '--nodejs-checks')
+    for switch in switches:
+        if switch in sys.argv:
+            return True
+    return False


### PR DESCRIPTION
Several projects have JavaScript files in the ALX SE course, but I could find only three projects that have node.js/executable JavaScript files, and they are all in the Foundations track:
- [0x12-javascript-warm_up](https://intranet.alxswe.com/projects/303)
- [0x13-javascript_objects_scopes_closures](https://intranet.alxswe.com/projects/304)
- [0x14-javascript-web_scraping](https://intranet.alxswe.com/projects/333)

With that in mind, I propose that you disable these two problematic checks for JavaScript by default, then have the user enable them manually when needed with a commandline switch/option like `js`, `nodejs-project`, etc. => `alxcheck -js`, `alxcheck --nodejs-project`. These are simply the two I chose. They can be changed easily using the tuple in the function I created.

> _**From my commit message:**_
> Node.js-specific checks for `*.js` files disabled by default. Enable with commandline switch.
> 
> **CHANGES**
> `alxcheck\utils\helpers.py`:
> \+ Added `is_nodejs_project` function to check if user passed the commandline switch.
> 
> `alxcheck\main.py`:
> \- Remove unused module import in line 1
> \* Change .utils.helpers import statement to include new helper function
> \* Make first two JavaScript checks conditional/based on new function's output.
> 
> `README.md`
> \* Indent notes to make hierarchy clearer
> \+ Add documentation for newly created helper function and its implementation.