### PR TITLE
fix: checks if files end with newline. closes #13

### DIFF
--- a/alxcheck/checks/general.py
+++ b/alxcheck/checks/general.py
@@ -18,5 +18,6 @@ def check_file_not_empty(file_path):
 def check_file_ends_with_new_line(file_path):
     if not check_file_not_empty(file_path):
         return False
-    with open(file_path, "r") as f:
-        return f.read()[-1] == "\n"
+
+    with open(file_path, "rb") as f:
+        return f.readlines()[-1] == b"\n"

--- a/alxcheck/main.py
+++ b/alxcheck/main.py
@@ -11,6 +11,8 @@ def main():
             sys.exit(1)
         if not check_file_not_empty("README.md"):
             print_file_empty("README.md")
+        if not check_file_ends_with_new_line("README.md"):
+            print_no_ending_new_line("README.md")
         for root, dirs, files in os.walk("."):
             # exclude virtual environment folders
             for dir in dirs:
@@ -24,7 +26,7 @@ def main():
                 file_path = os.path.join(root, file)
                 if file_path.endswith(
                     (".c", ".py", ".js", ".m", ".h",
-                     ".mjs", ".jsx", ".json", ".md")
+                     ".mjs", ".jsx", ".json")
                 ):
                     if not check_file_ends_with_new_line(file_path):
                         if not is_empty_init_py(file_path):

--- a/alxcheck/main.py
+++ b/alxcheck/main.py
@@ -23,7 +23,8 @@ def main():
             for file in files:
                 file_path = os.path.join(root, file)
                 if file_path.endswith(
-                    (".c", ".py", ".js", ".m", ".h", ".mjs", ".jsx", ".json")
+                    (".c", ".py", ".js", ".m", ".h",
+                     ".mjs", ".jsx", ".json", ".md")
                 ):
                     if not check_file_ends_with_new_line(file_path):
                         if not is_empty_init_py(file_path):


### PR DESCRIPTION
# Fix: checks if files end with newline.

## Changes:

**alxcheck\main.py:**
+ Added `".md"` in `line 26` to ensure files with **.md** extensions are checked for newline.

**alxcheck\checks\general.py:**
* Modified the `check_file_ends_with_new_line` function. Files should open in `binary mode` instead of `read text mode`. Instead using `read()` to `return a single string containing the entire content`, `readlines()` was used to `return list of lines`.